### PR TITLE
Add defaults for required template files

### DIFF
--- a/lib/Dist/Zilla/Plugin/Dpkg.pm
+++ b/lib/Dist/Zilla/Plugin/Dpkg.pm
@@ -255,7 +255,8 @@ to C<default_template>.
 has 'default_template_default' => (
     is => 'ro',
     isa => 'Str',
-    predicate => 'has_default_template_default'
+    predicate => 'has_default_template_default',
+    default => ''
 );
 
 =attr init_template
@@ -313,7 +314,8 @@ to C<install_template>.
 has 'install_template_default' => (
     is => 'ro',
     isa => 'Str',
-    predicate => 'has_install_template_default'
+    predicate => 'has_install_template_default',
+    default => "make install\n"
 );
 
 =attr package_depends
@@ -454,7 +456,8 @@ to C<postinst_template>.
 has 'postinst_template_default' => (
     is => 'ro',
     isa => 'Str',
-    predicate => 'has_postinst_template_default'
+    predicate => 'has_postinst_template_default',
+    default => ''
 );
 
 =attr postrm_template
@@ -483,7 +486,8 @@ to C<postrm_template>.
 has 'postrm_template_default' => (
     is => 'ro',
     isa => 'Str',
-    predicate => 'has_postrm_template_default'
+    predicate => 'has_postrm_template_default',
+    default => ''
 );
 
 =attr rules_template


### PR DESCRIPTION
Just enough code to make `dzil build` run. There is no indication that these will work. I would really like to know what good defaults are and where they should be located in the file system.

This is one approach.
Other fixes to https://github.com/gphat/dist-zilla-plugin-dpkg/issues/1 would be to add an improved example to the SYNOPSIS or add a section in the pod to describe what the **install**, **default**, **postinst** and **postrm** templates are for, what should be in them (with pointers to the Debian/Ubuntu docs) and where they should normally go in a standard Perl module source code layout. As it stands, it feels like there's a step that I'm missing to get this working out of the box.

Oooh, just found explanations of [postinst and postrm](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html), but what should they look like for Perl modules?  Is this what is needed for [install files](https://www.debian.org/doc/debian-policy/ch-source.html)? That just leaves what the default default template should contain.

I tried looking for examples in CPAN, but nobody has this plugin in their [dist.ini](https://grep.metacpan.org/search?size=20&_bb=163524847&q=Dpkg&qd=&qft=*.ini&qifl=&qls=on)

Essentially, what I'm looking for in this plugin is the ability to package my module and hand it off to the Ubuntu folks without having to learn too much about their ecosystem. I'd rather be writing Perl code ;). Not expecting that this PR gets merged. It's just that the forked repo doesn't have an Issues tab. I've raised one on the gphat's repo, but this PR will give us something to talk about.

cheers,
Boyd